### PR TITLE
Swap cursor when hovering over boxes

### DIFF
--- a/app/forked/display.rb
+++ b/app/forked/display.rb
@@ -42,6 +42,7 @@ module Forked
         next if option.action.empty?
 
         if option.intersect_rect?(inputs.mouse.point)
+          args.gtk.set_system_cursor(:hand)
           option.merge!(data.config.rollover_button_box)
 
           $story.follow(args, option) if args.inputs.mouse.up

--- a/app/tick.rb
+++ b/app/tick.rb
@@ -181,6 +181,7 @@ def roll dice
 end
 
 def tick args
+  args.gtk.set_system_cursor(:arrow)
   $timer_start = Time.now.to_f
 
   $story ||= Forked::Story.new


### PR DESCRIPTION
when you hover over a box, the rollover state highlights that you are hovering over it - but the mouse remains a pointer. This change makes it so that on systems that support it, you'll see a hand instead (see [docs](http://docs.dragonruby.org.s3-website-us-east-1.amazonaws.com/#-----set_system_cursor-)). The cursor is reset back to an arrow at the start of every tick so that it is only changed when hovering on something.

gif:

![forked-mouse-over-button-behavior](https://github.com/oeloeloel/forked/assets/60324/c3db7115-f655-411f-bae3-1e374548b157)
